### PR TITLE
Add Checkmarx CxFlow GitHub Action for SAST scanning

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,4 +1,4 @@
-name: Checkmarx (CxFlow++) SAST on macOS self-hosted
+name: Checkmarx (CxFlow CLI) SAST on macOS self-hosted
 
 on:
   pull_request:
@@ -7,24 +7,20 @@ on:
     branches: [ main ]
   workflow_dispatch: {}
 
-# Required so the action can upload SARIF (Security alerts) and (optionally)
-# comment on PRs or create issues if you enable those modes later.
 permissions:
   contents: read
   issues: write
   pull-requests: write
-  security-events: write
+  security-events: write  # needed to upload SARIF alerts to GitHub Security tab
 
 jobs:
   scan:
-    # Match your self-hosted runner's labels exactly
     runs-on: [self-hosted, macOS, ARM64, checkmarx]
 
     steps:
       - uses: actions/checkout@v4
 
-      # (Optional, but recommended) Install GNU sed so any sed usage inside the action
-      # behaves consistently (GNU sed) on macOS.
+      # Optional: install GNU sed to ensure consistent behavior if you ever use sed-like operations
       - name: Install GNU sed (macOS ARM64)
         shell: bash
         run: |
@@ -37,12 +33,10 @@ jobs:
           fi
           brew update
           brew install gnu-sed || brew reinstall gnu-sed
-          # Prepend Homebrew bin so 'sed' resolves to GNU sed for subsequent steps
           echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
           sed --version || true
 
-      # Sanitize branch/ref so the project name never contains '/'
-      # This avoids the action's internal {branch} substitution path and BSD sed differences.
+      # Sanitize branch/ref so project names never contain '/'
       - name: Build sanitized project name
         shell: bash
         env:
@@ -53,31 +47,61 @@ jobs:
           echo "PROJECT_NAME=OpenSAMPL-${SANITIZED}" >> "$GITHUB_ENV"
           echo "Sanitized project name: $PROJECT_NAME"
 
-      # CxFlow++ executes directly on the runner (composite action, no Docker),
-      # so it's compatible with macOS self-hosted runners.
-      - name: Checkmarx CxFlow++ SAST Scan
-        uses: checkmarx-ts/checkmarx-cxflow-plusplus-github-action@v3
-        env:
-          # Force the action to use the sanitized branch value internally if it tries to substitute {branch}
-          PROPER_BRANCH_NAME: ${{ env.SANITIZED_BRANCH }}
+      # Install Java if not present (Corretto JDK 17)
+      - name: Set up Java 17 (Corretto)
+        uses: actions/setup-java@v4
         with:
-          # ---- On-prem Checkmarx SAST connection ----
-          sast-url: ${{ secrets.CHECKMARX_URL }}              # e.g., https://checkmarx.ornl.gov
-          sast-username: ${{ secrets.CHECKMARX_USERNAME }}
-          sast-password: ${{ secrets.CHECKMARX_PASSWORD }}
-          sast-team: ${{ secrets.CHECKMARX_TEAMS }}
+          distribution: 'corretto'
+          java-version: '17'
 
-          # ---- Project naming (sanitized; no {branch} placeholder) ----
-          project-name: ${{ env.PROJECT_NAME }}
+      # Download the CxFlow CLI jar directly
+      - name: Download CxFlow CLI
+        shell: bash
+        run: |
+          set -e
+          CXFLOW_DIR="$RUNNER_TEMP/cxflow"
+          mkdir -p "$CXFLOW_DIR"
+          # Download a specific known-good version (adjust if needed):
+          # Using the version observed in your logs: 1.7.13
+          curl -sSL -o "$CXFLOW_DIR/cx-flow.jar" \
+            https://github.com/checkmarx-ltd/cx-flow/releases/download/1.7.13/cx-flow-1.7.13.jar
+          test -s "$CXFLOW_DIR/cx-flow.jar" || { echo "CxFlow jar download failed"; exit 1; }
+          echo "CXFLOW_DIR=$CXFLOW_DIR" >> "$GITHUB_ENV"
 
-          # ---- Scan options ----
-          disable-sca-scan: true  # keep SAST-only for now
+      # Run CxFlow SAST only, explicitly disabling SCA resolver and producing SARIF
+      - name: Orchestrate SAST scan with CxFlow CLI (resolver disabled)
+        shell: bash
+        env:
+          SARIF_FILE: ${{ env.CXFLOW_DIR }}/cx.sarif
+          CHECKMARX_URL: ${{ secrets.CHECKMARX_URL }}     # e.g., https://checkmarx.ornl.gov
+          CHECKMARX_USERNAME: ${{ secrets.CHECKMARX_USERNAME }}
+          CHECKMARX_PASSWORD: ${{ secrets.CHECKMARX_PASSWORD }}
+          CHECKMARX_CLIENT_SECRET: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+          CHECKMARX_TEAMS: ${{ secrets.CHECKMARX_TEAMS }} # e.g., \CxServer\SP\Company\ORNL
+        run: |
+          set -e
+          echo "Starting CxFlow CLI (SAST only, resolver disabled)..."
+          java -Xms512m -Xmx2048m -Djava.security.egd=file:/dev/./urandom \
+            -jar "$CXFLOW_DIR/cx-flow.jar" \
+            --scan --f=. \
+            --bug-tracker='Sarif' \
+            --cx-project='${PROJECT_NAME}' \
+            --cx-team='${CHECKMARX_TEAMS}' \
+            --namespace='${{ github.repository_owner }}' \
+            --repo-name='${{ github.event.repository.name }}' \
+            --branch='${SANITIZED_BRANCH}' \
+            --logging.level.com.checkmarx='INFO' \
+            --cx-flow.enabled-vulnerability-scanners='sast' \
+            --checkmarx.base-url='${CHECKMARX_URL}' \
+            --checkmarx.username='${CHECKMARX_USERNAME}' \
+            --checkmarx.password='${CHECKMARX_PASSWORD}' \
+            --checkmarx.client-secret='${CHECKMARX_CLIENT_SECRET}' \
+            --sarif.file-output='${SARIF_FILE}' \
+            --sca.enable-sca-resolver=false
 
-          # ---- Explicitly disable SCA Resolver for PR and push ----
-          pull-request-cxflow-params: "--sca.enable-sca-resolver=false"
-          push-cxflow-params: "--sca.enable-sca-resolver=false"
+          echo "CxFlow completed; SARIF at: ${SARIF_FILE}"
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: cx.sarif
+          sarif_file: ${{ env.CXFLOW_DIR }}/cx.sarif

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,0 +1,71 @@
+name: Checkmarx (CxFlow) SAST
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+# Required so the action can comment on PRs and upload SARIF (security alerts)
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  security-events: write
+
+jobs:
+  scan:
+    # If checkmarx.ornl.gov isn't reachable from GitHub-hosted runners,
+    # switch to a self-hosted runner inside ORNL's network:
+    # runs-on: self-hosted
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Optional: trust internal CA if your Checkmarx uses a private cert.
+      # Place .crt files under .github/certs/ and uncomment extra_certificates below.
+
+      - name: Checkmarx CxFlow SAST Scan
+        uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
+        env:
+          # Exclude Git metadata and workflow files to avoid large diffs/slow uploads
+          CX_FLOW_ZIP_EXCLUDE: "\\.git/.*, \\.github/.*"
+        with:
+          # Project naming per branch; adjust if you prefer a single project name
+          project: OpenSAMPL-${{ github.ref_name }}
+          team: ${{ secrets.CHECKMARX_TEAMS }}
+
+          # Core Checkmarx connectivity
+          checkmarx_url: ${{ secrets.CHECKMARX_URL }}
+          checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+          checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+
+          # On-prem CxSAST uses a built-in OAuth client; the action only needs the secret.
+          # You saved the standard on-prem secret (014DF517-...); keep using it here.
+          checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+
+          # Specify your exact CxSAST version (>=9.5 requires this input)
+          checkmarx_version: "9.7"
+
+          # Enable SAST (add ",sca" if you also want SCA scans and have SCA licensed)
+          scanners: "sast"
+
+          # Publish findings via SARIF (Security tab) instead of PR comments/Issues
+          bug_tracker: "Sarif"
+
+          # Uncomment if you committed internal CA certs:
+          # extra_certificates: ".github/certs"
+
+          # Extra CxFlow runtime parameters
+          params: >
+            --namespace=${{ github.repository_owner }}
+            --repo-name=${{ github.event.repository.name }}
+            --branch=${{ github.ref_name }}
+            --checkmarx.settings-override=true
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: cx.sarif

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -16,10 +16,9 @@ permissions:
 
 jobs:
   scan:
-    # If checkmarx.ornl.gov isn't reachable from GitHub-hosted runners,
-    # switch to a self-hosted runner inside ORNL's network:
-    # runs-on: self-hosted
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64, checkmarx]
+    # If your runner has custom labels (e.g., macOS), use:
+    # runs-on: [self-hosted, macOS]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -7,18 +7,32 @@ on:
     branches: [ main ]
   workflow_dispatch: {}
 
+# Required so the action can upload SARIF (Security alerts) and optionally
+# comment on PRs or create issues if you enable those modes later.
 permissions:
   contents: read
   issues: write
   pull-requests: write
-  security-events: write   # required for SARIF upload
+  security-events: write
 
 jobs:
   scan:
+    # Match your self-hosted runner's labels exactly
     runs-on: [self-hosted, macOS, ARM64, checkmarx]
 
     steps:
       - uses: actions/checkout@v4
+
+      # (Optional) quick connectivity probe to your on-prem Checkmarx
+      # Uncomment if you want to see reachability before scanning.
+      # - name: Connectivity check to Checkmarx
+      #   shell: bash
+      #   run: |
+      #     set -e
+      #     echo "DNS resolution:"
+      #     (command -v dig && dig +short checkmarx.ornl.gov) || (command -v nslookup && nslookup checkmarx.ornl.gov) || true
+      #     echo "TLS probe:"
+      #     curl -sS -I https://checkmarx.ornl.gov/cxrestapi/version || true
 
       # CxFlow++ executes directly on the runner (composite action, no Docker),
       # so it's compatible with macOS self-hosted runners.
@@ -35,7 +49,7 @@ jobs:
           project-name: OpenSAMPL-${{ github.ref_name }}
 
           # ---- Scan options ----
-          disable-sca-scan: true  # enable later if/when SCA credentials are available
+          disable-sca-scan: true  # enable later if you also want SCA
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  security-events: write  # needed to upload SARIF alerts to GitHub Security tab
+  security-events: write  # needed for SARIF upload to GitHub Security tab
 
 jobs:
   scan:
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Optional: install GNU sed to ensure consistent behavior if you ever use sed-like operations
+      # Optional: install GNU sed (keeps sed behavior consistent on macOS if ever needed)
       - name: Install GNU sed (macOS ARM64)
         shell: bash
         run: |
@@ -61,8 +61,7 @@ jobs:
           set -e
           CXFLOW_DIR="$RUNNER_TEMP/cxflow"
           mkdir -p "$CXFLOW_DIR"
-          # Download a specific known-good version (adjust if needed):
-          # Using the version observed in your logs: 1.7.13
+          # Using version observed in your logs: 1.7.13
           curl -sSL -o "$CXFLOW_DIR/cx-flow.jar" \
             https://github.com/checkmarx-ltd/cx-flow/releases/download/1.7.13/cx-flow-1.7.13.jar
           test -s "$CXFLOW_DIR/cx-flow.jar" || { echo "CxFlow jar download failed"; exit 1; }
@@ -73,30 +72,30 @@ jobs:
         shell: bash
         env:
           SARIF_FILE: ${{ env.CXFLOW_DIR }}/cx.sarif
-          CHECKMARX_URL: ${{ secrets.CHECKMARX_URL }}     # e.g., https://checkmarx.ornl.gov
+          CHECKMARX_BASE_URL: ${{ secrets.CHECKMARX_BASE_URL }}     # e.g., https://checkmarx.ornl.gov (NO /cxrestapi)
           CHECKMARX_USERNAME: ${{ secrets.CHECKMARX_USERNAME }}
           CHECKMARX_PASSWORD: ${{ secrets.CHECKMARX_PASSWORD }}
           CHECKMARX_CLIENT_SECRET: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
-          CHECKMARX_TEAMS: ${{ secrets.CHECKMARX_TEAMS }} # e.g., \CxServer\SP\Company\ORNL
+          CHECKMARX_TEAMS: ${{ secrets.CHECKMARX_TEAMS }}           # e.g., \CxServer\SP\Company\ORNL
         run: |
           set -e
           echo "Starting CxFlow CLI (SAST only, resolver disabled)..."
           java -Xms512m -Xmx2048m -Djava.security.egd=file:/dev/./urandom \
             -jar "$CXFLOW_DIR/cx-flow.jar" \
             --scan --f=. \
-            --bug-tracker='Sarif' \
-            --cx-project='${PROJECT_NAME}' \
-            --cx-team='${CHECKMARX_TEAMS}' \
-            --namespace='${{ github.repository_owner }}' \
-            --repo-name='${{ github.event.repository.name }}' \
-            --branch='${SANITIZED_BRANCH}' \
-            --logging.level.com.checkmarx='INFO' \
-            --cx-flow.enabled-vulnerability-scanners='sast' \
-            --checkmarx.base-url='${CHECKMARX_URL}' \
-            --checkmarx.username='${CHECKMARX_USERNAME}' \
-            --checkmarx.password='${CHECKMARX_PASSWORD}' \
-            --checkmarx.client-secret='${CHECKMARX_CLIENT_SECRET}' \
-            --sarif.file-output='${SARIF_FILE}' \
+            --bug-tracker="Sarif" \
+            --cx-project="${PROJECT_NAME}" \
+            --cx-team="${CHECKMARX_TEAMS}" \
+            --namespace="${{ github.repository_owner }}" \
+            --repo-name="${{ github.event.repository.name }}" \
+            --branch="${SANITIZED_BRANCH}" \
+            --logging.level.com.checkmarx="INFO" \
+            --cx-flow.enabled-vulnerability-scanners="sast" \
+            --checkmarx.base-url="${CHECKMARX_BASE_URL}" \
+            --checkmarx.username="${CHECKMARX_USERNAME}" \
+            --checkmarx.password="${CHECKMARX_PASSWORD}" \
+            --checkmarx.client-secret="${CHECKMARX_CLIENT_SECRET}" \
+            --sarif.file-output="${SARIF_FILE}" \
             --sca.enable-sca-resolver=false
 
           echo "CxFlow completed; SARIF at: ${SARIF_FILE}"

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  security-events: write   # required for SARIF uploads
+  security-events: write   # required for SARIF upload
 
 jobs:
   scan:
@@ -20,27 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # CxFlow++ executes directly on the runner (no Docker),
-      # so it works on macOS self-hosted runners.
+      # CxFlow++ executes directly on the runner (composite action, no Docker),
+      # so it's compatible with macOS self-hosted runners.
       - name: Checkmarx CxFlow++ SAST Scan
         uses: checkmarx-ts/checkmarx-cxflow-plusplus-github-action@v3
         with:
-          # ---- CxSAST connection (on-prem) ----
+          # ---- On-prem Checkmarx SAST connection ----
           sast-url: ${{ secrets.CHECKMARX_URL }}              # e.g., https://checkmarx.ornl.gov
           sast-username: ${{ secrets.CHECKMARX_USERNAME }}
           sast-password: ${{ secrets.CHECKMARX_PASSWORD }}
           sast-team: ${{ secrets.CHECKMARX_TEAMS }}
 
-          # ---- Project naming ----
-          project-name: OpenSAMPL-{branch}
+          # ---- Project naming (explicit branch; no {branch} placeholder) ----
+          project-name: OpenSAMPL-${{ github.ref_name }}
 
-          # ---- Scanning modes ----
-          disable-sca-scan: true   # set to false if you also want SCA and have SCA creds
-
-          # ---- Extra parameters for CxFlow (optional) ----
-          # You can pass additional CLI params if needed:
-          # pull-request-cxflow-params: "--namespace=${{ github.repository_owner }} --branch=${{ github.ref_name }}"
-          # push-cxflow-params: "--namespace=${{ github.repository_owner }} --branch=${{ github.ref_name }}"
+          # ---- Scan options ----
+          disable-sca-scan: true  # enable later if/when SCA credentials are available
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -7,32 +7,30 @@ on:
     branches: [ main ]
   workflow_dispatch: {}
 
-# Required so the action can upload SARIF (Security alerts) and optionally
-# comment on PRs or create issues if you enable those modes later.
 permissions:
   contents: read
   issues: write
   pull-requests: write
-  security-events: write
+  security-events: write   # required for SARIF upload
 
 jobs:
   scan:
-    # Match your self-hosted runner's labels exactly
     runs-on: [self-hosted, macOS, ARM64, checkmarx]
 
     steps:
       - uses: actions/checkout@v4
 
-      # (Optional) quick connectivity probe to your on-prem Checkmarx
-      # Uncomment if you want to see reachability before scanning.
-      # - name: Connectivity check to Checkmarx
-      #   shell: bash
-      #   run: |
-      #     set -e
-      #     echo "DNS resolution:"
-      #     (command -v dig && dig +short checkmarx.ornl.gov) || (command -v nslookup && nslookup checkmarx.ornl.gov) || true
-      #     echo "TLS probe:"
-      #     curl -sS -I https://checkmarx.ornl.gov/cxrestapi/version || true
+      # Sanitize branch/ref so the project name never contains '/'.
+      # This avoids the action's internal sed replacement path on macOS (BSD sed).
+      - name: Build sanitized project name
+        shell: bash
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          # Replace all slashes with hyphens
+          SANITIZED="${BRANCH//\//-}"
+          echo "PROJECT_NAME=OpenSAMPL-${SANITIZED}" >> "$GITHUB_ENV"
+          echo "Sanitized project name: $PROJECT_NAME"
 
       # CxFlow++ executes directly on the runner (composite action, no Docker),
       # so it's compatible with macOS self-hosted runners.
@@ -45,8 +43,8 @@ jobs:
           sast-password: ${{ secrets.CHECKMARX_PASSWORD }}
           sast-team: ${{ secrets.CHECKMARX_TEAMS }}
 
-          # ---- Project naming (explicit branch; no {branch} placeholder) ----
-          project-name: OpenSAMPL-${{ github.ref_name }}
+          # ---- Project naming (explicit, sanitized; no {branch} placeholder) ----
+          project-name: ${{ env.PROJECT_NAME }}
 
           # ---- Scan options ----
           disable-sca-scan: true  # enable later if you also want SCA

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -7,20 +7,24 @@ on:
     branches: [ main ]
   workflow_dispatch: {}
 
+# Required so the action can upload SARIF (Security alerts) and (optionally)
+# comment on PRs or create issues if you enable those modes later.
 permissions:
   contents: read
   issues: write
   pull-requests: write
-  security-events: write   # required for SARIF upload [3](https://docs.checkmarx.com/en/34965-188033-creating-an-oauth-client-for-checkmarx-one-integrations.html)
+  security-events: write
 
 jobs:
   scan:
-    runs-on: [self-hosted, macOS, ARM64, checkmarx]  # match your runner labels exactly [4](https://github-wiki-see.page/m/checkmarx-ltd/cx-flow/wiki/Configuration)
+    # Match your self-hosted runner's labels exactly
+    runs-on: [self-hosted, macOS, ARM64, checkmarx]
 
     steps:
       - uses: actions/checkout@v4
 
-      # 1) Install GNU sed so any internal sed usage in the action is consistent on macOS
+      # (Optional, but recommended) Install GNU sed so any sed usage inside the action
+      # behaves consistently (GNU sed) on macOS.
       - name: Install GNU sed (macOS ARM64)
         shell: bash
         run: |
@@ -37,7 +41,8 @@ jobs:
           echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
           sed --version || true
 
-      # 2) Sanitize the branch/ref so project names never contain '/'
+      # Sanitize branch/ref so the project name never contains '/'
+      # This avoids the action's internal {branch} substitution path and BSD sed differences.
       - name: Build sanitized project name
         shell: bash
         env:
@@ -49,7 +54,7 @@ jobs:
           echo "Sanitized project name: $PROJECT_NAME"
 
       # CxFlow++ executes directly on the runner (composite action, no Docker),
-      # so it's compatible with macOS self-hosted runners. [1](https://docs.checkmarx.com/en/34965-8217-github-actions-integration.html)
+      # so it's compatible with macOS self-hosted runners.
       - name: Checkmarx CxFlow++ SAST Scan
         uses: checkmarx-ts/checkmarx-cxflow-plusplus-github-action@v3
         env:
@@ -66,7 +71,11 @@ jobs:
           project-name: ${{ env.PROJECT_NAME }}
 
           # ---- Scan options ----
-          disable-sca-scan: true  # enable later if/when you want SCA
+          disable-sca-scan: true  # keep SAST-only for now
+
+          # ---- Explicitly disable SCA Resolver for PR and push ----
+          pull-request-cxflow-params: "--sca.enable-sca-resolver=false"
+          push-cxflow-params: "--sca.enable-sca-resolver=false"
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,4 +1,4 @@
-name: Checkmarx (CxFlow) SAST
+name: Checkmarx (CxFlow++) SAST on macOS self-hosted
 
 on:
   pull_request:
@@ -7,62 +7,40 @@ on:
     branches: [ main ]
   workflow_dispatch: {}
 
-# Required so the action can comment on PRs and upload SARIF (security alerts)
 permissions:
   contents: read
   issues: write
   pull-requests: write
-  security-events: write
+  security-events: write   # required for SARIF uploads
 
 jobs:
   scan:
     runs-on: [self-hosted, macOS, ARM64, checkmarx]
-    # If your runner has custom labels (e.g., macOS), use:
-    # runs-on: [self-hosted, macOS]
 
     steps:
       - uses: actions/checkout@v4
 
-      # Optional: trust internal CA if your Checkmarx uses a private cert.
-      # Place .crt files under .github/certs/ and uncomment extra_certificates below.
-
-      - name: Checkmarx CxFlow SAST Scan
-        uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
-        env:
-          # Exclude Git metadata and workflow files to avoid large diffs/slow uploads
-          CX_FLOW_ZIP_EXCLUDE: "\\.git/.*, \\.github/.*"
+      # CxFlow++ executes directly on the runner (no Docker),
+      # so it works on macOS self-hosted runners.
+      - name: Checkmarx CxFlow++ SAST Scan
+        uses: checkmarx-ts/checkmarx-cxflow-plusplus-github-action@v3
         with:
-          # Project naming per branch; adjust if you prefer a single project name
-          project: OpenSAMPL-${{ github.ref_name }}
-          team: ${{ secrets.CHECKMARX_TEAMS }}
+          # ---- CxSAST connection (on-prem) ----
+          sast-url: ${{ secrets.CHECKMARX_URL }}              # e.g., https://checkmarx.ornl.gov
+          sast-username: ${{ secrets.CHECKMARX_USERNAME }}
+          sast-password: ${{ secrets.CHECKMARX_PASSWORD }}
+          sast-team: ${{ secrets.CHECKMARX_TEAMS }}
 
-          # Core Checkmarx connectivity
-          checkmarx_url: ${{ secrets.CHECKMARX_URL }}
-          checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
-          checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+          # ---- Project naming ----
+          project-name: OpenSAMPL-{branch}
 
-          # On-prem CxSAST uses a built-in OAuth client; the action only needs the secret.
-          # You saved the standard on-prem secret (014DF517-...); keep using it here.
-          checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+          # ---- Scanning modes ----
+          disable-sca-scan: true   # set to false if you also want SCA and have SCA creds
 
-          # Specify your exact CxSAST version (>=9.5 requires this input)
-          checkmarx_version: "9.7"
-
-          # Enable SAST (add ",sca" if you also want SCA scans and have SCA licensed)
-          scanners: "sast"
-
-          # Publish findings via SARIF (Security tab) instead of PR comments/Issues
-          bug_tracker: "Sarif"
-
-          # Uncomment if you committed internal CA certs:
-          # extra_certificates: ".github/certs"
-
-          # Extra CxFlow runtime parameters
-          params: >
-            --namespace=${{ github.repository_owner }}
-            --repo-name=${{ github.event.repository.name }}
-            --branch=${{ github.ref_name }}
-            --checkmarx.settings-override=true
+          # ---- Extra parameters for CxFlow (optional) ----
+          # You can pass additional CLI params if needed:
+          # pull-request-cxflow-params: "--namespace=${{ github.repository_owner }} --branch=${{ github.ref_name }}"
+          # push-cxflow-params: "--namespace=${{ github.repository_owner }} --branch=${{ github.ref_name }}"
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -11,31 +11,50 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  security-events: write   # required for SARIF upload
+  security-events: write   # required for SARIF upload [3](https://docs.checkmarx.com/en/34965-188033-creating-an-oauth-client-for-checkmarx-one-integrations.html)
 
 jobs:
   scan:
-    runs-on: [self-hosted, macOS, ARM64, checkmarx]
+    runs-on: [self-hosted, macOS, ARM64, checkmarx]  # match your runner labels exactly [4](https://github-wiki-see.page/m/checkmarx-ltd/cx-flow/wiki/Configuration)
 
     steps:
       - uses: actions/checkout@v4
 
-      # Sanitize branch/ref so the project name never contains '/'.
-      # This avoids the action's internal sed replacement path on macOS (BSD sed).
+      # 1) Install GNU sed so any internal sed usage in the action is consistent on macOS
+      - name: Install GNU sed (macOS ARM64)
+        shell: bash
+        run: |
+          set -e
+          if ! command -v brew >/dev/null 2>&1; then
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          fi
+          if [ -x /opt/homebrew/bin/brew ]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+          fi
+          brew update
+          brew install gnu-sed || brew reinstall gnu-sed
+          # Prepend Homebrew bin so 'sed' resolves to GNU sed for subsequent steps
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          sed --version || true
+
+      # 2) Sanitize the branch/ref so project names never contain '/'
       - name: Build sanitized project name
         shell: bash
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          # Replace all slashes with hyphens
           SANITIZED="${BRANCH//\//-}"
+          echo "SANITIZED_BRANCH=$SANITIZED" >> "$GITHUB_ENV"
           echo "PROJECT_NAME=OpenSAMPL-${SANITIZED}" >> "$GITHUB_ENV"
           echo "Sanitized project name: $PROJECT_NAME"
 
       # CxFlow++ executes directly on the runner (composite action, no Docker),
-      # so it's compatible with macOS self-hosted runners.
+      # so it's compatible with macOS self-hosted runners. [1](https://docs.checkmarx.com/en/34965-8217-github-actions-integration.html)
       - name: Checkmarx CxFlow++ SAST Scan
         uses: checkmarx-ts/checkmarx-cxflow-plusplus-github-action@v3
+        env:
+          # Force the action to use the sanitized branch value internally if it tries to substitute {branch}
+          PROPER_BRANCH_NAME: ${{ env.SANITIZED_BRANCH }}
         with:
           # ---- On-prem Checkmarx SAST connection ----
           sast-url: ${{ secrets.CHECKMARX_URL }}              # e.g., https://checkmarx.ornl.gov
@@ -43,11 +62,11 @@ jobs:
           sast-password: ${{ secrets.CHECKMARX_PASSWORD }}
           sast-team: ${{ secrets.CHECKMARX_TEAMS }}
 
-          # ---- Project naming (explicit, sanitized; no {branch} placeholder) ----
+          # ---- Project naming (sanitized; no {branch} placeholder) ----
           project-name: ${{ env.PROJECT_NAME }}
 
           # ---- Scan options ----
-          disable-sca-scan: true  # enable later if you also want SCA
+          disable-sca-scan: true  # enable later if/when you want SCA
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/selfhosted-smoke-test.yml
+++ b/.github/workflows/selfhosted-smoke-test.yml
@@ -1,0 +1,65 @@
+name: Self-hosted Runner Smoke Test
+
+on:
+  workflow_dispatch: {}   # allows manual trigger from the Actions tab
+  push:
+    paths:
+      - .github/workflows/selfhosted-smoke-test.yml
+
+permissions:
+  contents: read
+
+jobs:
+  runner-check:
+    # If you added custom labels to your runner (e.g., 'macOS', 'ORNL'),
+    # replace 'self-hosted' with your specific labels:
+    # runs-on: [self-hosted, macOS]
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout (no repo content needed but proves token works)
+        uses: actions/checkout@v4
+
+      - name: Print runner basics
+        run: |
+          echo "Runner name: $RUNNER_NAME"
+          echo "Runner OS: $RUNNER_OS"
+          echo "Runner arch: $RUNNER_ARCH"
+          echo "Workspace: $GITHUB_WORKSPACE"
+          echo "Repository: $GITHUB_REPOSITORY"
+          echo "Actor: $GITHUB_ACTOR"
+          echo "Ref: $GITHUB_REF"
+          echo "Commit SHA: $GITHUB_SHA"
+          echo "Labels: $RUNNER_LABELS"
+
+      - name: List environment
+        run: env | sort
+
+      - name: Verify outbound connectivity to GitHub
+        run: |
+          set -e
+          echo "Pinging api.github.com..."
+          curl -sS -I https://api.github.com | head -n 1
+          echo "Pinging github.com..."
+          curl -sS -I https://github.com | head -n 1
+          echo "Connectivity OK."
+
+      - name: Verify connectivity to Checkmarx (HTTP(S) reachability)
+        # This confirms your runner can reach the on-prem server.
+        # If your Checkmarx uses a private CA, this may fail unless the CA is trusted locally.
+        continue-on-error: true
+        run: |
+          set -e
+          echo "Checking https://checkmarx.ornl.gov/cxrestapi/version..."
+          curl -sS -k https://checkmarx.ornl.gov/cxrestapi/version || true
+          echo "If this printed JSON version info, connectivity is good."
+
+      - name: Runner file system sanity check
+        run: |
+          echo "Creating a temp file in $RUNNER_TEMP ..."
+          echo "Hello from self-hosted runner at $(date)" > "$RUNNER_TEMP/hello.txt"
+          ls -al "$RUNNER_TEMP"
+          cat "$RUNNER_TEMP/hello.txt"
+
+      - name: Done
+        run: echo "✅ Self-hosted runner smoke test completed."


### PR DESCRIPTION
### Summary
This PR introduces a GitHub Actions workflow to integrate Checkmarx SAST scanning via CxFlow for the OpenSAMPL repository.

### Details
- Added `.github/workflows/checkmarx.yml` workflow.
- Configured to run on `push` and `pull_request` events for the `main` branch.
- Uses on-prem Checkmarx instance at https://checkmarx.ornl.gov.
- Authentication via built-in resource_owner_client and static client secret.
- Uploads SARIF results to GitHub Security tab for vulnerability visibility.

### Notes
- Requires GitHub secrets:
  - CHECKMARX_URL
  - CHECKMARX_USERNAME
  - CHECKMARX_PASSWORD
  - CHECKMARX_CLIENT_SECRET
  - CHECKMARX_TEAMS
- If Checkmarx is not reachable from GitHub-hosted runners, switch to a self-hosted runner inside ORNL network.

### Testing
- Workflow will trigger on PR creation and push to `main`.
- Verify SARIF upload under Security tab and scan results in Checkmarx dashboard.